### PR TITLE
Standardize spacing in gce-all-active-app.conf

### DIFF
--- a/gce-nginx-plus-deployment-guide-files/etc_nginx_conf.d/gce-all-active-app.conf
+++ b/gce-nginx-plus-deployment-guide-files/etc_nginx_conf.d/gce-all-active-app.conf
@@ -1,31 +1,29 @@
-#server1 conf file
+#conf file for server1, a sample application in the all-active NGINX Plus load balancing deployment on Google Compute Engine (GCE)
 server {
-	listen 80 default_server;
-        server_name _;
-	root /usr/share/nginx/server1;
-	error_log	/var/log/nginx/app-server-error.log	notice;
-	index		index.php index.html;
+    listen      80 default_server;
+    server_name _;
+    root        /usr/share/nginx/server1;
+    error_log	/var/log/nginx/app-server-error.log	notice;
+    index       index.php index.html;
 
-	location ~* \.php$ {
- 		try_files $uri = 404;   
-        	root           /usr/share/nginx/php;
-        	fastcgi_pass   127.0.0.1:9000;
-        	fastcgi_index  index.php;
-        	fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-        	include        fastcgi_params;
+    location ~* \.php$ {
+        try_files      $uri = 404;   
+        root           /usr/share/nginx/php;
+        fastcgi_pass   127.0.0.1:9000;
+        fastcgi_index  index.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+        include        fastcgi_params;
 
-		add_header 'X-Upstream-Addr' '$upstream_addr' always;
-       		add_header 'X-Proxy-Header' "NGINX Plus Proxy_Pass" always;
-		add_header 'X-App-Server' "Application-Server" always;
-
-	}
+        add_header 'X-Upstream-Addr' '$upstream_addr' always;
+        add_header 'X-Proxy-Header' "NGINX Plus Proxy_Pass" always;
+        add_header 'X-App-Server' "Application-Server" always;
+    }
 	
-	location /images {
-		root /usr/share/nginx;
-	}
+    location /images {
+        root /usr/share/nginx;
+    }
 
-	location ~ /favicon.ico {
-		root /usr/share/nginx/images;
-	}
-
+    location ~ /favicon.ico {
+        root /usr/share/nginx/images;
+    }
 }


### PR DESCRIPTION
Standardizing formatting of .conf file to use 4 spaces per level of indent, not a mix of tabs and space.